### PR TITLE
add option for vertical layout

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -9,6 +9,9 @@
     <entry name="showIconsOnly" type="Bool">
       <default>false</default>
     </entry>
+    <entry name="useVerticalLayout" type="Bool">
+      <default>false</default>
+    </entry>
   </group>
 
 </kcfg>

--- a/package/contents/ui/ConfigGeneral.qml
+++ b/package/contents/ui/ConfigGeneral.qml
@@ -24,12 +24,17 @@ import QtQuick.Controls 1.0
 
 Item {
     property alias cfg_showIconsOnly: showIconsOnly.checked
+    property alias cfg_useVerticalLayout: useVerticalLayout.checked
 
     ColumnLayout {
         Layout.fillWidth: true
         CheckBox {
             id: showIconsOnly
             text: i18n("Show icons only")
+        }
+        CheckBox {
+            id: useVerticalLayout
+            text: i18n("Use vertical layout")
         }
     }
 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -22,6 +22,7 @@ import QtQuick 2.2
 import QtQuick.Layouts 1.0
 import QtQuick.Controls 1.2 as QtControls
 
+import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.components 2.0 as PlasmaComponents
 import org.kde.plasma.plasmoid 2.0
 
@@ -31,11 +32,12 @@ import org.kde.plasma.private.volume 0.1
 Item {
     id: main
 
-    Layout.minimumWidth: rowLayout.implicitWidth
-    Layout.minimumHeight: rowLayout.implicitHeight
+    Layout.minimumWidth: gridLayout.implicitWidth
+    Layout.minimumHeight: gridLayout.implicitHeight
     Plasmoid.preferredRepresentation: Plasmoid.fullRepresentation
 
     property bool showIconsOnly: plasmoid.configuration.showIconsOnly
+    property bool useVerticalLayout: plasmoid.configuration.useVerticalLayout
 
     // from plasma-volume-control applet
     function iconNameFromPort(port, fallback) {
@@ -55,8 +57,9 @@ Item {
         return fallback;
     }
 
-    RowLayout {
-        id: rowLayout
+    GridLayout {
+        id: gridLayout
+        flow: useVerticalLayout == true ? GridLayout.TopToBottom : GridLayout.LeftToRight
         anchors.fill: parent
 
         QtControls.ExclusiveGroup {


### PR DESCRIPTION
This commit replaces the `RowLayout` with a `GridLayout` and adds a config option to switch between the `GridLayout.LeftToRight` and `GridLayout.TopToBottom` flow options, which is helpful if using the widget in a vertical panel.

Ideally the widget could detect that it's in a vertical panel and do this automatically, but I'm rather new to Plasma/QML dev and am not sure of the best approach to do so.

Should fix issue #2.