### PR TITLE
Improved descriptions on buttons

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -86,7 +86,7 @@ Item {
 
                 readonly property var sink: model.PulseObject
                 readonly property var currentPort: model.Ports[ActivePortIndex]
-                readonly property string currentDescription: currentPort ? currentPort.description : model.Description
+                readonly property string currentDescription: model.Description
 
                 Binding {
                     target: tab


### PR DESCRIPTION
Use model.Description insted of currentPort.description, because currentPort.description is almost always "Speakers"