### PR TITLE
Fix issue with buttons overflow on bottom in panel

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -81,6 +81,7 @@ Item {
                 exclusiveGroup: buttonGroup
                 tooltip: currentDescription
 
+                Layout.fillHeight: true
                 Layout.fillWidth: true
                 Layout.preferredWidth: showIconsOnly ? -1 : units.gridUnit * 10
 


### PR DESCRIPTION
When widget is added in taskbar panel, and panel's height is small (30px), buttons used to go off-screen on bottom. 
This PR fixes this issue.