### PR TITLE
Improved descriptions and icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ Makefile*
 # QtCtreator CMake
 CMakeLists.txt.user*
 
+# KDevelop
+*.kdev4
+/.kdev4
+/build

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -6,10 +6,24 @@
   <kcfgfile name=""/>
 
   <group name="General">
-    <entry name="showIconsOnly" type="Bool">
-      <default>false</default>
+    <entry name="labeling" type="Enum">
+      <choices>
+        <choice name="iconWithDescription">
+          <label>Icon with description</label>
+        </choice>
+        <choice name="descriptionOnly">
+          <label>Description only</label>
+        </choice>
+        <choice name="iconOnly">
+          <label>Icon only</label>
+        </choice>
+        <default>iconWithDescription</default>
+      </choices>
     </entry>
     <entry name="useVerticalLayout" type="Bool">
+      <default>false</default>
+    </entry>
+    <entry name="usePortDescription" type="Bool">
       <default>false</default>
     </entry>
   </group>

--- a/package/contents/ui/ConfigGeneral.qml
+++ b/package/contents/ui/ConfigGeneral.qml
@@ -23,14 +23,38 @@ import QtQuick.Layouts 1.0
 import QtQuick.Controls 1.0
 
 Item {
-    property alias cfg_showIconsOnly: showIconsOnly.checked
+    property int cfg_labeling: 0
+    property alias cfg_usePortDescription: usePortDescription.checked
     property alias cfg_useVerticalLayout: useVerticalLayout.checked
 
     ColumnLayout {
         Layout.fillWidth: true
+        
+        ColumnLayout {
+            id: labeling
+            ExclusiveGroup { id: labelingGroup }
+            Repeater {
+                id: buttonRepeater
+                model: [
+                    i18n("Show icon with description"),
+                    i18n("Show description only"),
+                    i18n("Show icon only")
+                ]
+                RadioButton {
+                    text: modelData
+                    checked: index === cfg_labeling
+                    exclusiveGroup: labelingGroup
+                    onClicked: {
+                        cfg_labeling = index
+                    }
+                }
+            }
+        }
+        
         CheckBox {
-            id: showIconsOnly
-            text: i18n("Show icons only")
+            id: usePortDescription
+            enabled: cfg_labeling != 2 // "Icon only"
+            text: i18n("Use the audio sink's port description rather than the sink description")
         }
         CheckBox {
             id: useVerticalLayout

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -36,30 +36,49 @@ Item {
     Layout.minimumHeight: gridLayout.implicitHeight
     Plasmoid.preferredRepresentation: Plasmoid.fullRepresentation
 
-    property bool showIconsOnly: plasmoid.configuration.showIconsOnly
+    property int labeling: plasmoid.configuration.labeling
     property bool useVerticalLayout: plasmoid.configuration.useVerticalLayout
+    property bool usePortDescription: plasmoid.configuration.usePortDescription
 
     // from plasma-volume-control applet
-    function iconNameFromPort(port, fallback) {
-        if (port) {
-            if (port.name.indexOf("speaker") !== -1) {
+    // see https://github.com/KDE/plasma-pa/blob/master/applet/contents/code/icon.js
+    function formFactorIcon(formFactor) {
+        switch(formFactor) {
+            case "internal":
+                return "audio-card";
+            case "speaker":
                 return "audio-speakers-symbolic";
-            } else if (port.name.indexOf("headphones") !== -1) {
-                return "audio-headphones";
-            } else if (port.name.indexOf("hdmi") !== -1) {
-                return "video-television";
-            } else if (port.name.indexOf("mic") !== -1) {
-                return "audio-input-microphone";
-            } else if (port.name.indexOf("phone") !== -1) {
+            case "phone":
                 return "phone";
-            }
+            case "handset":
+                return "phone";
+            case "tv":
+                return "video-television";
+            case "webcam":
+                return "camera-web";
+            case "microphone":
+                return "audio-input-microphone";
+            case "headset":
+                return "audio-headset";
+            case "headphone":
+                return "audio-headphones";
+            case "hands-free":
+                return "hands-free";
+            case "car":
+                return "car";
+            case "hifi":
+                return "hifi";
+            case "computer":
+                return "computer";
+            case "portable":
+                return "portable";
         }
-        return fallback;
+        return "audio-volume-high"; // fallback
     }
-
+    
     GridLayout {
         id: gridLayout
-        flow: useVerticalLayout == true ? GridLayout.TopToBottom : GridLayout.LeftToRight
+        flow: useVerticalLayout? GridLayout.TopToBottom : GridLayout.LeftToRight
         anchors.fill: parent
 
         QtControls.ExclusiveGroup {
@@ -74,20 +93,20 @@ Item {
                 id: tab
                 enabled: currentPort !== null
 
-                text: showIconsOnly ? "" : currentDescription
-                iconName: showIconsOnly ? iconNameFromPort(currentPort, IconName) : ""
+                text: labeling != 2 ? currentDescription : ""
+                iconName: labeling != 1 ? formFactorIcon(sink.formFactor) : ""
 
                 checkable: true
                 exclusiveGroup: buttonGroup
                 tooltip: currentDescription
 
                 Layout.fillWidth: true
-                Layout.preferredWidth: showIconsOnly ? -1 : units.gridUnit * 10
+                Layout.preferredWidth: -1
 
                 readonly property var sink: model.PulseObject
                 readonly property var currentPort: model.Ports[ActivePortIndex]
-                readonly property string currentDescription: currentPort ? currentPort.description : model.Description
-
+                readonly property string currentDescription: usePortDescription? currentPort ? currentPort.description : model.Description : model.Description
+                
                 Binding {
                     target: tab
                     property: "checked"


### PR DESCRIPTION
Add option for description of sink vs port, similar to [hadogenes](https://github.com/akrutzler/plasma-audio-device-switcher/pull/13).  Add option for labeling by description, icon, or both.  Enhance icon selection.